### PR TITLE
에러 리포팅(센트리, 디스코드)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ jobs:
           cd /home/${{ secrets.SSH_USER }}/baam-server
           npm install
           npm run build
-          npm run start
+          nohup npm run start > /dev/null 2>&1 &
           EOF
         env:
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@nestjs/swagger": "^7.3.1",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.3.9",
+    "@sentry/nestjs": "^8.23.0",
+    "@sentry/profiling-node": "^8.23.0",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/common/filters/http-exception/internal-server-exception.filter.ts
+++ b/src/common/filters/http-exception/internal-server-exception.filter.ts
@@ -20,14 +20,14 @@ export class InternalServerErrorFilter extends BaseExceptionFilter {
     const { method, body, query, params, url, headers, _startTime } =
       http.getRequest();
 
-    ReportProvider.report(exception, {
+    ReportProvider.error(exception, {
       method,
       body,
       query,
       params,
       url,
       headers,
-      startTime: _startTime,
+      _startTime,
     });
 
     // Error Log

--- a/src/common/filters/http-exception/internal-server-exception.filter.ts
+++ b/src/common/filters/http-exception/internal-server-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 import { BaseExceptionFilter } from '@nestjs/core';
 import { Response } from 'express';
 import { ErrorCode } from './../../constants/error-codes';
+import { ReportProvider } from 'src/common/provider/report.provider';
 
 // 핸들링 되지 않은 서버 에러
 @Catch()
@@ -16,7 +17,18 @@ export class InternalServerErrorFilter extends BaseExceptionFilter {
     const http = host.switchToHttp();
     const response = http.getResponse<Response>();
 
-    // TODO: 에러 리포팅
+    const { method, body, query, params, url, headers, _startTime } =
+      http.getRequest();
+
+    ReportProvider.report(exception, {
+      method,
+      body,
+      query,
+      params,
+      url,
+      headers,
+      startTime: _startTime,
+    });
 
     // Error Log
     Logger.error(exception.message);

--- a/src/common/provider/report.provider.ts
+++ b/src/common/provider/report.provider.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node';
+
+export class ReportProvider {
+  static report(error: Error, extra: Record<string, unknown>): void {
+    Sentry.withScope((scope) => {
+      Object.entries(extra).forEach(([key, value]) =>
+        scope.setExtra(key, value),
+      );
+      Sentry.captureException(error);
+    });
+  }
+}

--- a/src/common/provider/report.provider.ts
+++ b/src/common/provider/report.provider.ts
@@ -12,7 +12,7 @@ export class ReportProvider {
     this.errorReport('error', error, extra, moduleName);
   }
 
-  static report(
+  static info(
     message: string,
     extra?: Record<string, unknown>,
     moduleName?: string,
@@ -21,6 +21,13 @@ export class ReportProvider {
       message,
       extra: { ...extra, moduleName },
       level: 'info',
+    });
+
+    this.sendToDiscord({
+      severity: 'info',
+      title: message,
+      extra,
+      moduleName,
     });
   }
 
@@ -53,11 +60,43 @@ export class ReportProvider {
     });
 
     // Send error to Discord
+    this.sendToDiscord({
+      severity,
+      title: error.message,
+      error,
+      extra,
+      moduleName,
+    });
+  }
+
+  private static sendToDiscord(params: {
+    severity: SeverityLevel;
+    title: string;
+    error?: Error;
+    extra?: Record<string, unknown>;
+    moduleName?: string;
+  }): void {
+    const { severity, title, error, extra, moduleName } = params;
+    let color: number;
+    switch (severity) {
+      case 'error':
+        color = 15400960;
+        break;
+      case 'warning':
+        color = 16744770;
+        break;
+
+      default:
+        color = 3742673;
+        break;
+    }
+
     const data = {
       embeds: [
         {
-          title: `[${severity}]: ${error.message}`,
-          description: error.stack,
+          title: [severity, moduleName, title].filter(Boolean).join(' - '),
+          color,
+          description: error?.stack,
           fields: Object.entries({ ...extra }).map(([key, value]) => ({
             name: key,
             value: JSON.stringify(value),

--- a/src/common/provider/report.provider.ts
+++ b/src/common/provider/report.provider.ts
@@ -1,12 +1,74 @@
+import { Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
+import axios from 'axios';
+import { SeverityLevel } from '@sentry/nestjs';
 
 export class ReportProvider {
-  static report(error: Error, extra: Record<string, unknown>): void {
+  static error(
+    error: Error,
+    extra?: Record<string, unknown>,
+    moduleName?: string,
+  ): void {
+    this.errorReport('error', error, extra, moduleName);
+  }
+
+  static report(
+    message: string,
+    extra?: Record<string, unknown>,
+    moduleName?: string,
+  ): void {
+    Sentry.captureEvent({
+      message,
+      extra: { ...extra, moduleName },
+      level: 'info',
+    });
+  }
+
+  static warn(
+    error: Error,
+    extra?: Record<string, unknown>,
+    moduleName?: string,
+  ): void {
+    this.errorReport('warning', error, extra, moduleName);
+  }
+
+  private static errorReport(
+    severity: SeverityLevel,
+    error: Error,
+    extra?: Record<string, unknown>,
+    moduleName?: string,
+  ): void {
     Sentry.withScope((scope) => {
-      Object.entries(extra).forEach(([key, value]) =>
-        scope.setExtra(key, value),
-      );
+      if (extra) {
+        for (const [key, value] of Object.entries(extra)) {
+          scope.setExtra(key, value);
+        }
+      }
+
+      if (moduleName) {
+        scope.setExtra('moduleName', moduleName);
+      }
+      scope.setLevel(severity);
       Sentry.captureException(error);
     });
+
+    // Send error to Discord
+    const data = {
+      embeds: [
+        {
+          title: `[${severity}]: ${error.message}`,
+          description: error.stack,
+          fields: Object.entries({ ...extra }).map(([key, value]) => ({
+            name: key,
+            value: JSON.stringify(value),
+            inline: true,
+          })),
+        },
+      ],
+    };
+
+    axios
+      .post(process.env.DISCORD_WEBHOOK_URL!, data)
+      .catch((err) => Logger.error(err));
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import morganBody from 'morgan-body';
 import helmet from 'helmet';
 import { IncomingMessage, ServerResponse } from 'http';
 import { v4 as uuidV4 } from 'uuid';
+import * as Sentry from '@sentry/node';
 
 import { LogProvider } from './common/provider/log.provider';
 import { setupSwagger } from './docs/setup-swagger';
@@ -52,6 +53,13 @@ async function bootstrap() {
       contentSecurityPolicy: false,
     }),
   );
+
+  Sentry.init({
+    dsn: environmentService.get<string>('SENTRY_DSN'),
+    enabled: environmentService.get<boolean>('USE_SENTRY'),
+    environment: environmentService.get<string>('ENV'),
+    attachStacktrace: true,
+  });
 
   morganBody(app.getHttpAdapter().getInstance(), {
     noColors: true,

--- a/src/module/environment/environment.ts
+++ b/src/module/environment/environment.ts
@@ -118,6 +118,11 @@ export class EnvironmentVariables {
   @Type(() => Boolean)
   @Expose()
   readonly USE_SENTRY: boolean;
+
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  readonly DISCORD_WEBHOOK_URL: string;
 }
 
 export const getEnvFilePath = (): string =>

--- a/src/module/environment/environment.ts
+++ b/src/module/environment/environment.ts
@@ -107,6 +107,17 @@ export class EnvironmentVariables {
   @IsString()
   @Expose()
   readonly NEIS_API_KEY: string;
+
+  // Sentry
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  readonly SENTRY_DSN: string;
+
+  @IsBoolean()
+  @Type(() => Boolean)
+  @Expose()
+  readonly USE_SENTRY: boolean;
 }
 
 export const getEnvFilePath = (): string =>


### PR DESCRIPTION
# Pull Request 🗒️

- 레벨은 센트리 레벨 사용(`info`, `warning`, `error`)
- `USE_SENTRY` : 센트리에 리포팅 여부 (로컬에서 작업시 false 로 설정)
- 현재 에러 리포팅은 '**_핸들링 되지 않은 500 에러_**' 에만 '`error`' 레벨로 사용중
- report(), warn() 은 이후에 필요시 사용


`SENTRY_DSN`, `DISCORD_WEBHOOK_URL` 을 포함한
.env 파일 >  디스코드 백엔드 채널에 공유했습니다

#

<센트리>  (순서대로 error - warning - info)
<img width="1068" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/06d743f8-a883-4581-89ce-aa8602856fea">

#

<디스코드>
<img width="683" alt="image" src="https://github.com/user-attachments/assets/898404fc-2c86-4f1e-aef4-33f39b186d41">



## 변경 유형

- [ ] 코드에 영향 없는 변경(변수명, 파일명, 폴더명, 오타 수정, 포맷 변경)
- [ ] 코드 리팩토링 (기능에 영향을 주지 않는 변경사항)
- [X] 새로운 기능 (기존 기능을 망가뜨리지 않는 새로운 기능 추가)
- [ ] 파괴적인 변경 (기존 기능에 영향을 미치는 수정)
- [ ] 버그 수정 (기존 기능을 망가뜨리지 않는 수정)
- [ ] 문서 업데이트(API 문서)
- [ ] 주석 변경
- [ ] 테스트 생성/리팩터링
- [ ] 기타: <!--- 설명 -->

